### PR TITLE
fix: Player Should Automatically Lose When Dealer Is Dealt Blackjack

### DIFF
--- a/src/components/dealer/dealer.tsx
+++ b/src/components/dealer/dealer.tsx
@@ -38,6 +38,21 @@ export const Dealer = (props: DealerProps) => {
         }
     }, [props.playerFinalTotals])
 
+    useEffect(() => {
+        const initialTotal = calculateHandOfCardsTotal(
+            dealerState.blackjackHand.cards
+        )
+        if (initialTotal.blackjack) {
+            setDealerState({
+                blackjackHand: {
+                    ...dealerState.blackjackHand,
+                    finished: true,
+                },
+            })
+            props.onHasFinishedPlaying(dealerState.blackjackHand.cards)
+        }
+    }, [])
+
     function isDealerOpeningHand(): boolean {
         return (
             dealerState.blackjackHand.cards.length === 2 &&


### PR DESCRIPTION
## Summary

Forces player to automatically lose when dealer is dealt a blackjack.

## Changes

- Updated dealer logic to evaluate initial hand and immediately finish the round if they start with Blackjack.

Fixes jacketattack/blackjack-is-fun#19