### PR TITLE
fix: resolve css modules typing discrepancy

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ node_modules/
 dist/
 plan
 parcel-bundle-reports/
+*.module.css.d.ts

--- a/src/components/player-hand-result/player-hand-result.module.css.d.ts
+++ b/src/components/player-hand-result/player-hand-result.module.css.d.ts
@@ -1,7 +1,8 @@
 declare const styles: {
-    readonly result: string
-    readonly winner: string
-    readonly loser: string
-    readonly push: string
-}
-export = styles
+  readonly "result": string;
+  readonly "winner": string;
+  readonly "loser": string;
+  readonly "push": string;
+};
+export = styles;
+

--- a/src/components/player/player.module.css.d.ts
+++ b/src/components/player/player.module.css.d.ts
@@ -1,7 +1,8 @@
 declare const styles: {
-    readonly player: string
-    readonly name: string
-    readonly hands: string
-    readonly hand: string
-}
-export = styles
+  readonly "player": string;
+  readonly "name": string;
+  readonly "hands": string;
+  readonly "hand": string;
+};
+export = styles;
+


### PR DESCRIPTION
## Summary

Resolves the discrepancy between Parcel-generated CSS module typings and the linter/Prettier.

## Changes

- Added `*.module.css.d.ts` to `.prettierignore` to prevent Prettier from modifying the typing files generated by Parcel (via `parcel-transformer-ts-css-modules`). This ensures that the husky pre-commit hook does not revert formatting changes that Parcel expects, allowing commits to proceed smoothly.

Fixes jacketattack/blackjack-is-fun#25