### PR TITLE
19: Fix Player Should Automatically Lose When Dealer Has Blackjack

### DIFF
--- a/src/components/app/app.test.tsx
+++ b/src/components/app/app.test.tsx
@@ -46,6 +46,15 @@ test('Player won', () => {
     expect(screen.getByText('WINNER')).toBeInTheDocument()
 })
 
+test('Player lost when dealer is dealt a blackjack', () => {
+    mockDealHand(CardValue.ACE, CardValue.KING) // Dealer
+    mockDealHand(CardValue.TEN, CardValue.TEN) // Player
+
+    render(<App />)
+
+    expect(screen.getByText('LOSER')).toBeInTheDocument()
+})
+
 function mockDealHand(
     firstCardValue: CardValue,
     secondCardValue: CardValue,

--- a/src/components/dealer/dealer.tsx
+++ b/src/components/dealer/dealer.tsx
@@ -29,6 +29,7 @@ export const Dealer = (props: DealerProps) => {
             !hasPlayerBusted() &&
             !dealerState.blackjackHand.finished
         ) {
+            // Dealer plays out hand if player has finished and hasn't busted
             const dealerFinalHand: Card[] = playDealerHand(
                 dealerState.blackjackHand.cards
             )
@@ -40,6 +41,7 @@ export const Dealer = (props: DealerProps) => {
             })
             props.onHasFinishedPlaying(dealerFinalHand)
         } else if (hasPlayerFinishedPlaying() && hasPlayerBusted()) {
+            // Dealer does not need to play out hand if player has busted
             props.onHasFinishedPlaying(dealerState.blackjackHand.cards)
         } else if (
             dealerTotalIsTwentyOne() &&

--- a/src/components/dealer/dealer.tsx
+++ b/src/components/dealer/dealer.tsx
@@ -35,6 +35,8 @@ export const Dealer = (props: DealerProps) => {
                 },
             })
             props.onHasFinishedPlaying(dealerFinalHand)
+        } else if (hasPlayerFinishedPlaying() && hasPlayerBusted()) {
+            props.onHasFinishedPlaying(dealerState.blackjackHand.cards)
         }
     }, [props.playerFinalTotals])
 

--- a/src/components/dealer/dealer.tsx
+++ b/src/components/dealer/dealer.tsx
@@ -24,7 +24,11 @@ export const Dealer = (props: DealerProps) => {
         blackjackHand: dealHand(),
     })
     useEffect(() => {
-        if (hasPlayerFinishedPlaying() && !hasPlayerBusted()) {
+        if (
+            hasPlayerFinishedPlaying() &&
+            !hasPlayerBusted() &&
+            !dealerState.blackjackHand.finished
+        ) {
             const dealerFinalHand: Card[] = playDealerHand(
                 dealerState.blackjackHand.cards
             )
@@ -36,6 +40,13 @@ export const Dealer = (props: DealerProps) => {
             })
             props.onHasFinishedPlaying(dealerFinalHand)
         } else if (hasPlayerFinishedPlaying() && hasPlayerBusted()) {
+            props.onHasFinishedPlaying(dealerState.blackjackHand.cards)
+        } else if (
+            dealerTotalIsTwentyOne() &&
+            dealerState.blackjackHand.cards.length === 2 &&
+            !hasPlayerFinishedPlaying()
+        ) {
+            // Dealer has blackjack or 21 on deal, and player hasn't finished yet
             props.onHasFinishedPlaying(dealerState.blackjackHand.cards)
         }
     }, [props.playerFinalTotals])

--- a/src/components/player/player.test.tsx
+++ b/src/components/player/player.test.tsx
@@ -50,6 +50,38 @@ describe('Player Component', () => {
         expect(onFinished).toHaveBeenCalled()
     })
 
+    test('automatically stands when dealer has blackjack', () => {
+        const onFinished = jest.fn()
+        mockInitialDeal([
+            { value: CardValue.TEN, suit: CardSuit.CLUBS },
+            { value: CardValue.TEN, suit: CardSuit.CLUBS },
+        ])
+
+        // Dealer has Blackjack (Ace + King)
+        const dealerHand = [
+            { value: CardValue.ACE, suit: CardSuit.SPADES },
+            { value: CardValue.KING, suit: CardSuit.SPADES },
+        ]
+
+        const { rerender } = render(
+            <Player
+                name="PLAYER"
+                dealerHand={[]}
+                onHasFinishedActions={onFinished}
+            />
+        )
+
+        rerender(
+            <Player
+                name="PLAYER"
+                dealerHand={dealerHand}
+                onHasFinishedActions={onFinished}
+            />
+        )
+
+        expect(onFinished).toHaveBeenCalled()
+    })
+
     test('draws card when hitting', () => {
         mockInitialDeal([
             { value: CardValue.TEN, suit: CardSuit.CLUBS },

--- a/src/components/player/player.tsx
+++ b/src/components/player/player.tsx
@@ -31,9 +31,8 @@ export const Player = (props: PlayerProps) => {
         activeHandIndex: 0,
     })
 
-    const dealerHandTotal: CardTotal = useHandOfCardsTotal(props.dealerHand)
     useEffect(() => {
-        if (dealerHandTotal.blackjack || dealerTotalIsTwentyOne()) {
+        if (dealerTotalIsTwentyOne()) {
             const finishedHands = finishActiveHand(playerState.blackjackHands)
             setPlayerState((prevState) => ({
                 ...prevState,
@@ -42,7 +41,9 @@ export const Player = (props: PlayerProps) => {
             }))
             props.onHasFinishedActions(finishedHands)
         }
-    }, [dealerHandTotal, props.dealerHand])
+    }, [props.dealerHand])
+
+    const dealerHandTotal: CardTotal = useHandOfCardsTotal(props.dealerHand)
 
     function dealerTotalIsTwentyOne(): boolean {
         return calculateHandOfCardsTotal(props.dealerHand).total === 21

--- a/src/components/player/player.tsx
+++ b/src/components/player/player.tsx
@@ -34,7 +34,13 @@ export const Player = (props: PlayerProps) => {
     const dealerHandTotal: CardTotal = useHandOfCardsTotal(props.dealerHand)
     useEffect(() => {
         if (dealerHandTotal.blackjack || dealerTotalIsTwentyOne()) {
-            stand()
+            const finishedHands = finishActiveHand(playerState.blackjackHands)
+            setPlayerState((prevState) => ({
+                ...prevState,
+                blackjackHands: finishedHands,
+                activeHandIndex: finishedHands.length,
+            }))
+            props.onHasFinishedActions(finishedHands)
         }
     }, [dealerHandTotal, props.dealerHand])
 

--- a/src/components/player/player.tsx
+++ b/src/components/player/player.tsx
@@ -144,6 +144,9 @@ export const Player = (props: PlayerProps) => {
     function finishActiveHand(
         blackjackHands: BlackjackHand[]
     ): BlackjackHand[] {
+        if (!blackjackHands[playerState.activeHandIndex]) {
+            return blackjackHands
+        }
         const copyOfBlackjackHands: BlackjackHand[] = [...blackjackHands]
         copyOfBlackjackHands[playerState.activeHandIndex].finished = true
 

--- a/src/components/player/player.tsx
+++ b/src/components/player/player.tsx
@@ -33,10 +33,14 @@ export const Player = (props: PlayerProps) => {
 
     const dealerHandTotal: CardTotal = useHandOfCardsTotal(props.dealerHand)
     useEffect(() => {
-        if (dealerHandTotal.blackjack) {
+        if (dealerHandTotal.blackjack || dealerTotalIsTwentyOne()) {
             stand()
         }
-    }, [dealerHandTotal])
+    }, [dealerHandTotal, props.dealerHand])
+
+    function dealerTotalIsTwentyOne(): boolean {
+        return calculateHandOfCardsTotal(props.dealerHand).total === 21
+    }
 
     function hit(): void {
         const handsOfCardsWithActiveHandHit: BlackjackHand[] =


### PR DESCRIPTION
Implements fix for issue #19:
- Player is now forced to 'stand' immediately if the dealer is dealt a natural Blackjack or 21.
- Updated Dealer component to ensure game state is finalized correctly when player busts.
- Re-implemented on a clean branch off the latest master.