### PR TITLE
18: Implement six-deck shoe with 75% penetration limit

### DIFF
--- a/src/services/deck.test.ts
+++ b/src/services/deck.test.ts
@@ -1,0 +1,48 @@
+import { dealHand, drawCard } from './deck';
+import { CardValue, CardSuit } from '../interfaces/card.interface';
+
+describe('deck service', () => {
+    it('should draw a card and reduce shoe size', () => {
+        const card = drawCard();
+        expect(card).toBeDefined();
+        expect(Object.values(CardValue)).toContain(card.value);
+        expect(Object.values(CardSuit)).toContain(card.suit);
+    });
+
+    it('should deal a hand with two cards', () => {
+        const hand = dealHand();
+        expect(hand.cards.length).toBe(2);
+        expect(hand.finished).toBe(false);
+    });
+
+    it('should maintain a shoe across multiple draws', () => {
+        // Drawing many cards should not crash and should return valid cards
+        for (let i = 0; i < 100; i++) {
+            const card = drawCard();
+            expect(card).toBeDefined();
+        }
+    });
+
+    it('should reshuffle when penetration limit is reached', () => {
+        // The shoe has 6 decks = 312 cards. 
+        // Penetration limit is 75% = 234 cards.
+        // At 234 cards used (78 cards left), dealHand should trigger reshuffle.
+        
+        // This is a bit tricky to test without exposing 'shoe' or 'buildNewShoe',
+        // but we can observe behavior by drawing almost the whole shoe.
+        
+        // Clear/reset shoe by drawing until empty if needed (state persists in module)
+        // Since we can't reset, we just draw enough to hit the limit.
+        const totalCards = 6 * 52;
+        const limit = totalCards * 0.75;
+        
+        // Draw enough to be near the limit
+        for (let i = 0; i < limit + 10; i++) {
+            drawCard();
+        }
+        
+        // This dealHand should have triggered a reshuffle if we were past limit
+        const hand = dealHand();
+        expect(hand.cards.length).toBe(2);
+    });
+});

--- a/src/services/deck.ts
+++ b/src/services/deck.ts
@@ -1,4 +1,4 @@
-import sample from 'lodash/sample'
+import shuffle from 'lodash/shuffle'
 import {
     BlackjackHand,
     Card,
@@ -6,7 +6,13 @@ import {
     CardValue,
 } from '../interfaces/card.interface'
 
+const NUMBER_OF_DECKS = 6
+const PENETRATION_LIMIT = 0.75
+
+let shoe: Card[] = []
+
 export function dealHand(): BlackjackHand {
+    checkShoePenetration()
     return {
         cards: [drawCard(), drawCard()],
         finished: false,
@@ -14,10 +20,10 @@ export function dealHand(): BlackjackHand {
 }
 
 export function drawCard(): Card {
-    return {
-        value: sample(Object.values(CardValue)) as CardValue,
-        suit: sample(Object.values(CardSuit)) as CardSuit,
+    if (shoe.length === 0) {
+        buildNewShoe()
     }
+    return shoe.pop()!
 }
 
 export function drawPair(): BlackjackHand {
@@ -33,5 +39,25 @@ export function drawPair(): BlackjackHand {
             },
         ],
         finished: false,
+    }
+}
+
+function buildNewShoe(): void {
+    const newShoe: Card[] = []
+    for (let i = 0; i < NUMBER_OF_DECKS; i++) {
+        Object.values(CardSuit).forEach((suit) => {
+            Object.values(CardValue).forEach((value) => {
+                newShoe.push({ suit, value })
+            })
+        })
+    }
+    shoe = shuffle(newShoe)
+}
+
+function checkShoePenetration(): void {
+    const totalCards = NUMBER_OF_DECKS * 52
+    const usedCards = totalCards - shoe.length
+    if (shoe.length === 0 || usedCards / totalCards >= PENETRATION_LIMIT) {
+        buildNewShoe()
     }
 }


### PR DESCRIPTION
Implements issue #18:
- Updated `deck.ts` to use a stateful six-deck shoe.
- Implemented `buildNewShoe` to generate and shuffle 312 cards (6 * 52).
- Added `checkShoePenetration` to trigger a reshuffle once 75% of the shoe is consumed.
- Reshuffle check is performed at the start of each new hand (`dealHand`) as requested.
- Shoe is persisted in module memory, resetting on page refresh.