### PR TITLE
Implement betting and bankroll management

### DIFF
--- a/src/components/app/app.module.css
+++ b/src/components/app/app.module.css
@@ -5,3 +5,14 @@
 .player {
     margin-top: 25px;
 }
+
+.bankroll {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    font-size: x-large;
+    font-weight: bold;
+    background-color: rgba(255, 255, 255, 0.8);
+    padding: 10px;
+    border-radius: 5px;
+}

--- a/src/components/app/app.test.tsx
+++ b/src/components/app/app.test.tsx
@@ -17,6 +17,7 @@ test('Player and dealer totals are displayed after finishing game', async () => 
     mockDealHand(CardValue.SEVEN, CardValue.SEVEN)
 
     render(<App />)
+    fireEvent.click(screen.getByText('New Game'))
 
     fireEvent.click(screen.getByText('STAND'))
 
@@ -29,6 +30,7 @@ test('Player is dealt two kings', () => {
     mockDealHand(CardValue.KING, CardValue.KING)
 
     render(<App />)
+    fireEvent.click(screen.getByText('New Game'))
 
     fireEvent.click(screen.getByText('SPLIT'))
 
@@ -40,6 +42,7 @@ test('Player won', () => {
     mockDealHand(CardValue.ACE, CardValue.TEN)
 
     render(<App />)
+    fireEvent.click(screen.getByText('New Game'))
 
     fireEvent.click(screen.getByText('STAND'))
 
@@ -51,6 +54,7 @@ test('Player lost when dealer is dealt a blackjack', () => {
     mockDealHand(CardValue.TEN, CardValue.TEN) // Player
 
     render(<App />)
+    fireEvent.click(screen.getByText('New Game'))
 
     expect(screen.getByText('LOSER')).toBeInTheDocument()
 })
@@ -62,7 +66,7 @@ function mockDealHand(
     firstCardSuit: CardSuit = CardSuit.CLUBS,
     secondCardSuit: CardSuit = CardSuit.DIAMONDS
 ) {
-    jest.spyOn(deck, 'dealHand').mockReturnValueOnce({
+    return jest.spyOn(deck, 'dealHand').mockImplementation(() => ({
         cards: [
             {
                 value: firstCardValue,
@@ -74,5 +78,6 @@ function mockDealHand(
             },
         ],
         finished: finished,
-    })
+        bet: 10,
+    }))
 }

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -12,7 +12,11 @@ interface AppState {
     dealerHand: Card[]
 }
 
+const MANDATORY_BET = 10
+const INITIAL_BANKROLL = 100
+
 export function App() {
+    let [bankroll, setBankroll] = useState(INITIAL_BANKROLL)
     let [appState, setAppState]: [
         AppState,
         Dispatch<SetStateAction<AppState>>,
@@ -28,6 +32,11 @@ export function App() {
             (hand: BlackjackHand) => calculateHandOfCardsTotal(hand.cards).total
         )
 
+        // Resolve bets
+        const dealerTotal = calculateHandOfCardsTotal(appState.dealerHand).total // appState.dealerHand might not be final yet here
+        // Wait, notifyDealerToPlay is called when player finishes. Dealer then plays.
+        // Bankroll should be updated AFTER dealer finishes.
+
         setAppState({
             ...appState,
             playerFinalTotals,
@@ -41,10 +50,23 @@ export function App() {
         })
     }
 
+    function startNewGame() {
+        if (bankroll < MANDATORY_BET) {
+            alert('Not enough bankroll to play!')
+            return
+        }
+        setBankroll((prev) => prev - MANDATORY_BET)
+        setAppState({
+            playerFinalTotals: [],
+            dealerHand: [],
+        })
+    }
+
     return (
         <>
             <div className={styles.game}>
                 <Title />
+                <button onClick={startNewGame}>New Game</button>
                 <Dealer
                     playerFinalTotals={appState.playerFinalTotals}
                     onHasFinishedPlaying={setDealerFinalHandOfCards}
@@ -53,7 +75,19 @@ export function App() {
                     name="PLAYER"
                     onHasFinishedActions={notifyDealerToPlay}
                     dealerHand={appState.dealerHand}
+                    initialBet={MANDATORY_BET}
+                    onBetPlaced={(amount) =>
+                        setBankroll((prev) => prev - amount)
+                    }
+                    onWinningsReceived={(amount) =>
+                        setBankroll((prev) => prev + amount)
+                    }
+                    gameStarted={
+                        appState.playerFinalTotals.length === 0 &&
+                        appState.dealerHand.length === 0
+                    }
                 />
+                <div className={styles.bankroll}>Bankroll: ${bankroll}</div>
             </div>
         </>
     )

--- a/src/components/player-actions/player-actions.module.css
+++ b/src/components/player-actions/player-actions.module.css
@@ -27,4 +27,11 @@
 .actionButtons {
     margin-top: 30px;
     display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.betDisplay {
+    margin-right: 15px;
+    font-size: large;
 }

--- a/src/components/player-actions/player-actions.tsx
+++ b/src/components/player-actions/player-actions.tsx
@@ -1,40 +1,59 @@
-import classNames from "classnames";
-import { Card } from "../../interfaces/card.interface";
-import * as styles from './player-actions.module.css';
+import classNames from 'classnames'
+import { Card } from '../../interfaces/card.interface'
+import * as styles from './player-actions.module.css'
 
 interface PlayerActionsProps {
-    handOfCards: Card[];
-    onHit(): void;
-    onDoubleDown(): void;
-    onSplit(): void;
-    onStand(): void;
+    handOfCards: Card[]
+    bet: number
+    onHit(): void
+    onDoubleDown(): void
+    onSplit(): void
+    onStand(): void
 }
 
 export const PlayerActions = (props: PlayerActionsProps) => {
     return (
         <div className={styles.actionButtons}>
-            <button onClick={props.onHit} className={classNames(styles.actionButton, styles.hit)}>HIT</button>
+            <div className={styles.betDisplay}>
+                <b>Bet:</b> {props.bet}
+            </div>
+            <button
+                onClick={props.onHit}
+                className={classNames(styles.actionButton, styles.hit)}
+            >
+                HIT
+            </button>
             <button
                 onClick={props.onDoubleDown}
                 disabled={!canDoubleDown(props.handOfCards)}
-                className={classNames(styles.actionButton, styles.doubleDown)}>
+                className={classNames(styles.actionButton, styles.doubleDown)}
+            >
                 DOUBLE DOWN
             </button>
             <button
                 onClick={props.onSplit}
                 disabled={!canSplit(props.handOfCards)}
-                className={classNames(styles.actionButton, styles.split)}>
+                className={classNames(styles.actionButton, styles.split)}
+            >
                 SPLIT
             </button>
-            <button onClick={props.onStand} className={classNames(styles.actionButton, styles.stand)}>STAND</button>
+            <button
+                onClick={props.onStand}
+                className={classNames(styles.actionButton, styles.stand)}
+            >
+                STAND
+            </button>
         </div>
-    );
+    )
 }
 
 function canDoubleDown(handOfCards: Card[]): boolean {
-    return handOfCards.length === 2;
+    return handOfCards.length === 2
 }
 
 function canSplit(handOfCards: Card[]): boolean {
-    return handOfCards.length === 2 && handOfCards[0].value === handOfCards[1].value;
+    return (
+        handOfCards.length === 2 &&
+        handOfCards[0].value === handOfCards[1].value
+    )
 }

--- a/src/components/player/player.test.tsx
+++ b/src/components/player/player.test.tsx
@@ -8,11 +8,12 @@ import { CardSuit, CardValue } from '../../interfaces/card.interface'
 describe('Player Component', () => {
     afterEach(cleanup)
 
-    function mockInitialDeal(cards: any[]) {
-        jest.spyOn(deck, 'dealHand').mockReturnValue({
+    function mockInitialDeal(cards: any[], bet: number = 10) {
+        return jest.spyOn(deck, 'dealHand').mockImplementation(() => ({
             cards: cards,
             finished: false,
-        })
+            bet: bet,
+        }))
     }
 
     test('renders player name', () => {
@@ -25,6 +26,10 @@ describe('Player Component', () => {
                 name="TEST PLAYER"
                 dealerHand={[]}
                 onHasFinishedActions={jest.fn()}
+                initialBet={10}
+                onBetPlaced={jest.fn()}
+                onWinningsReceived={jest.fn()}
+                gameStarted={false}
             />
         )
         expect(screen.getByText('TEST PLAYER')).toBeInTheDocument()
@@ -42,6 +47,10 @@ describe('Player Component', () => {
                 name="PLAYER"
                 dealerHand={[]}
                 onHasFinishedActions={onFinished}
+                initialBet={10}
+                onBetPlaced={jest.fn()}
+                onWinningsReceived={jest.fn()}
+                gameStarted={false}
             />
         )
 
@@ -68,6 +77,10 @@ describe('Player Component', () => {
                 name="PLAYER"
                 dealerHand={[]}
                 onHasFinishedActions={onFinished}
+                initialBet={10}
+                onBetPlaced={jest.fn()}
+                onWinningsReceived={jest.fn()}
+                gameStarted={false}
             />
         )
 
@@ -76,6 +89,10 @@ describe('Player Component', () => {
                 name="PLAYER"
                 dealerHand={dealerHand}
                 onHasFinishedActions={onFinished}
+                initialBet={10}
+                onBetPlaced={jest.fn()}
+                onWinningsReceived={jest.fn()}
+                gameStarted={false}
             />
         )
 
@@ -97,6 +114,10 @@ describe('Player Component', () => {
                 name="PLAYER"
                 dealerHand={[]}
                 onHasFinishedActions={jest.fn()}
+                initialBet={10}
+                onBetPlaced={jest.fn()}
+                onWinningsReceived={jest.fn()}
+                gameStarted={false}
             />
         )
 
@@ -128,6 +149,10 @@ describe('Player Component', () => {
                 name="PLAYER"
                 dealerHand={[]}
                 onHasFinishedActions={jest.fn()}
+                initialBet={10}
+                onBetPlaced={jest.fn()}
+                onWinningsReceived={jest.fn()}
+                gameStarted={false}
             />
         )
 

--- a/src/components/player/player.tsx
+++ b/src/components/player/player.tsx
@@ -15,11 +15,16 @@ interface PlayerProps {
     name: string
     dealerHand: Card[]
     onHasFinishedActions(playerFinalHandsOfCards: BlackjackHand[]): void
+    initialBet: number
+    onBetPlaced(amount: number): void
+    onWinningsReceived(amount: number): void
+    gameStarted: boolean
 }
 
 interface PlayerState {
     blackjackHands: BlackjackHand[]
     activeHandIndex: number
+    winningsProcessed: boolean
 }
 
 export const Player = (props: PlayerProps) => {
@@ -27,9 +32,20 @@ export const Player = (props: PlayerProps) => {
         PlayerState,
         Dispatch<SetStateAction<PlayerState>>,
     ] = useState({
-        blackjackHands: [dealHand()],
+        blackjackHands: [dealHand(props.initialBet)],
         activeHandIndex: 0,
+        winningsProcessed: false,
     })
+
+    useEffect(() => {
+        if (props.gameStarted) {
+            setPlayerState({
+                blackjackHands: [dealHand(props.initialBet)],
+                activeHandIndex: 0,
+                winningsProcessed: false,
+            })
+        }
+    }, [props.gameStarted, props.initialBet])
 
     useEffect(() => {
         if (dealerTotalIsTwentyOne()) {
@@ -45,6 +61,43 @@ export const Player = (props: PlayerProps) => {
 
     const dealerHandTotal: CardTotal = useHandOfCardsTotal(props.dealerHand)
 
+    // Handle winnings
+    useEffect(() => {
+        if (
+            playerIsFinished() &&
+            props.dealerHand.length > 0 &&
+            !playerState.winningsProcessed
+        ) {
+            const dealerTotal = calculateHandOfCardsTotal(
+                props.dealerHand
+            ).total
+            let totalWinnings = 0
+
+            playerState.blackjackHands.forEach((hand) => {
+                const playerTotal = calculateHandOfCardsTotal(hand.cards).total
+                if (playerTotal <= 21) {
+                    if (dealerTotal > 21 || playerTotal > dealerTotal) {
+                        // Win
+                        totalWinnings += hand.bet * 2
+                    } else if (playerTotal === dealerTotal) {
+                        // Push
+                        totalWinnings += hand.bet
+                    }
+                }
+            })
+
+            if (totalWinnings > 0) {
+                props.onWinningsReceived(totalWinnings)
+            }
+            setPlayerState((prev) => ({ ...prev, winningsProcessed: true }))
+        }
+    }, [
+        playerState.blackjackHands,
+        playerState.activeHandIndex,
+        props.dealerHand,
+        playerState.winningsProcessed,
+    ])
+
     function dealerTotalIsTwentyOne(): boolean {
         return calculateHandOfCardsTotal(props.dealerHand).total === 21
     }
@@ -59,12 +112,17 @@ export const Player = (props: PlayerProps) => {
     }
 
     function doubleDown(): void {
+        const activeHand =
+            playerState.blackjackHands[playerState.activeHandIndex]
+        props.onBetPlaced(activeHand.bet)
+
         const handsOfCardsWithActiveHandHit: BlackjackHand[] =
-            addCardToActiveHand()
+            addCardToActiveHand(activeHand.bet * 2)
         finishActiveHand(handsOfCardsWithActiveHandHit)
 
         const newActiveHandIndex: number = getNextActiveHandIndex()
         setPlayerState({
+            ...playerState,
             blackjackHands: handsOfCardsWithActiveHandHit,
             activeHandIndex: newActiveHandIndex,
         })
@@ -75,16 +133,21 @@ export const Player = (props: PlayerProps) => {
     }
 
     function split(): void {
-        const splitCard: Card =
-            playerState.blackjackHands[playerState.activeHandIndex].cards[0]
+        const activeHand =
+            playerState.blackjackHands[playerState.activeHandIndex]
+        props.onBetPlaced(activeHand.bet)
+
+        const splitCard: Card = activeHand.cards[0]
         const splitHands: BlackjackHand[] = [
             {
                 cards: [splitCard, drawCard()],
                 finished: false,
+                bet: activeHand.bet,
             },
             {
                 cards: [splitCard, drawCard()],
                 finished: false,
+                bet: activeHand.bet,
             },
         ]
         const copyOfBlackjackHands: BlackjackHand[] = [
@@ -105,13 +168,15 @@ export const Player = (props: PlayerProps) => {
     function stand(): void {
         const newActiveHandIndex: number = getNextActiveHandIndex()
 
+        const finishedHands = finishActiveHand(playerState.blackjackHands)
         setPlayerState({
-            blackjackHands: finishActiveHand(playerState.blackjackHands),
+            ...playerState,
+            blackjackHands: finishedHands,
             activeHandIndex: newActiveHandIndex,
         })
 
         if (playerIsFinished(newActiveHandIndex)) {
-            props.onHasFinishedActions(playerState.blackjackHands)
+            props.onHasFinishedActions(finishedHands)
         }
     }
 
@@ -134,14 +199,13 @@ export const Player = (props: PlayerProps) => {
         return playerState.blackjackHands.length
     }
 
-    function addCardToActiveHand(): BlackjackHand[] {
+    function addCardToActiveHand(newBet?: number): BlackjackHand[] {
+        const activeHand =
+            playerState.blackjackHands[playerState.activeHandIndex]
         const handWithNewCardAdded: BlackjackHand = {
-            ...playerState.blackjackHands[playerState.activeHandIndex],
-            cards: [
-                ...playerState.blackjackHands[playerState.activeHandIndex]
-                    .cards,
-                drawCard(),
-            ],
+            ...activeHand,
+            cards: [...activeHand.cards, drawCard()],
+            bet: newBet !== undefined ? newBet : activeHand.bet,
         }
         const copyOfHandsOfCards = [...playerState.blackjackHands]
         copyOfHandsOfCards[playerState.activeHandIndex] = handWithNewCardAdded
@@ -194,6 +258,7 @@ export const Player = (props: PlayerProps) => {
                                             playerState.activeHandIndex
                                         ].cards
                                     }
+                                    bet={hand.bet}
                                     onHit={hit}
                                     onDoubleDown={doubleDown}
                                     onSplit={split}

--- a/src/interfaces/card.interface.ts
+++ b/src/interfaces/card.interface.ts
@@ -1,6 +1,7 @@
 export interface BlackjackHand {
     cards: Card[]
     finished: boolean
+    bet: number
 }
 
 export interface Card {

--- a/src/services/deck.test.ts
+++ b/src/services/deck.test.ts
@@ -1,48 +1,49 @@
-import { dealHand, drawCard } from './deck';
-import { CardValue, CardSuit } from '../interfaces/card.interface';
+import { dealHand, drawCard } from './deck'
+import { CardValue, CardSuit } from '../interfaces/card.interface'
 
 describe('deck service', () => {
     it('should draw a card and reduce shoe size', () => {
-        const card = drawCard();
-        expect(card).toBeDefined();
-        expect(Object.values(CardValue)).toContain(card.value);
-        expect(Object.values(CardSuit)).toContain(card.suit);
-    });
+        const card = drawCard()
+        expect(card).toBeDefined()
+        expect(Object.values(CardValue)).toContain(card.value)
+        expect(Object.values(CardSuit)).toContain(card.suit)
+    })
 
-    it('should deal a hand with two cards', () => {
-        const hand = dealHand();
-        expect(hand.cards.length).toBe(2);
-        expect(hand.finished).toBe(false);
-    });
+    it('should deal a hand with two cards and a bet', () => {
+        const hand = dealHand(10)
+        expect(hand.cards.length).toBe(2)
+        expect(hand.finished).toBe(false)
+        expect(hand.bet).toBe(10)
+    })
 
     it('should maintain a shoe across multiple draws', () => {
         // Drawing many cards should not crash and should return valid cards
         for (let i = 0; i < 100; i++) {
-            const card = drawCard();
-            expect(card).toBeDefined();
+            const card = drawCard()
+            expect(card).toBeDefined()
         }
-    });
+    })
 
     it('should reshuffle when penetration limit is reached', () => {
-        // The shoe has 6 decks = 312 cards. 
+        // The shoe has 6 decks = 312 cards.
         // Penetration limit is 75% = 234 cards.
         // At 234 cards used (78 cards left), dealHand should trigger reshuffle.
-        
+
         // This is a bit tricky to test without exposing 'shoe' or 'buildNewShoe',
         // but we can observe behavior by drawing almost the whole shoe.
-        
+
         // Clear/reset shoe by drawing until empty if needed (state persists in module)
         // Since we can't reset, we just draw enough to hit the limit.
-        const totalCards = 6 * 52;
-        const limit = totalCards * 0.75;
-        
+        const totalCards = 6 * 52
+        const limit = totalCards * 0.75
+
         // Draw enough to be near the limit
         for (let i = 0; i < limit + 10; i++) {
-            drawCard();
+            drawCard()
         }
-        
+
         // This dealHand should have triggered a reshuffle if we were past limit
-        const hand = dealHand();
-        expect(hand.cards.length).toBe(2);
-    });
-});
+        const hand = dealHand()
+        expect(hand.cards.length).toBe(2)
+    })
+})

--- a/src/services/deck.ts
+++ b/src/services/deck.ts
@@ -11,11 +11,12 @@ const PENETRATION_LIMIT = 0.75
 
 let shoe: Card[] = []
 
-export function dealHand(): BlackjackHand {
+export function dealHand(bet: number = 0): BlackjackHand {
     checkShoePenetration()
     return {
         cards: [drawCard(), drawCard()],
         finished: false,
+        bet: bet,
     }
 }
 
@@ -39,6 +40,7 @@ export function drawPair(): BlackjackHand {
             },
         ],
         finished: false,
+        bet: 0,
     }
 }
 


### PR DESCRIPTION
Implements mandatory betting and bankroll features for issue #11.

- Players start with $100.
- Each hand requires a $10 bet.
- Winnings are added back to bankroll.
- Added Bankroll display and Bet indicator.
- Updated unit tests for Player and Deck services.