### PR TITLE
feat: Add Deck Penetration and Reshuffling Logic

### DIFF
--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -3,6 +3,7 @@ import { Dispatch, SetStateAction, useState } from 'react'
 import { BlackjackHand, Card } from '../../interfaces/card.interface'
 import calculateHandOfCardsTotal from '../../services/handOfCardsCalculation'
 import { Dealer } from '../dealer/dealer'
+import { DeckStatus } from '../deck-status/deck-status'
 import { Player } from '../player/player'
 import { Title } from '../title/title'
 import * as styles from './app.module.css'
@@ -44,6 +45,7 @@ export function App() {
     return (
         <div className={styles.game}>
             <Title />
+            <DeckStatus />
             <Dealer
                 playerFinalTotals={appState.playerFinalTotals}
                 onHasFinishedPlaying={setDealerFinalHandOfCards}

--- a/src/components/deck-status/deck-status.module.css
+++ b/src/components/deck-status/deck-status.module.css
@@ -1,0 +1,82 @@
+.deckStatusContainer {
+    position: fixed;
+    top: 20px;
+    left: 20px;
+    z-index: 1000;
+}
+
+.deckStatusContent {
+    background: rgba(0, 0, 0, 0.7);
+    padding: 12px 16px;
+    border-radius: 8px;
+    color: white;
+    font-family: Arial, sans-serif;
+    font-size: 0.9em;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.statusItem {
+    display: flex;
+    justify-content: space-between;
+    margin: 4px 0;
+}
+
+.statusLabel {
+    color: #ccc;
+    margin-right: 8px;
+}
+
+.statusValue {
+    font-weight: bold;
+}
+
+.penetrationLow {
+    color: #22c55e;
+}
+
+.penetrationMedium {
+    color: #fbbf24;
+}
+
+.penetrationHigh {
+    color: #f97316;
+}
+
+.penetrationReshuffleSoon {
+    color: #ef4444;
+}
+
+.reshuffleNotification {
+    position: absolute;
+    top: -50px;
+    left: 0;
+    background: #22c55e;
+    color: white;
+    padding: 10px 20px;
+    border-radius: 8px;
+    font-weight: bold;
+    animation:
+        slideDown 0.3s ease-out,
+        fadeOut 0.3s ease-in 2.7s forwards;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+@keyframes slideDown {
+    from {
+        opacity: 0;
+        transform: translateY(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes fadeOut {
+    from {
+        opacity: 1;
+    }
+    to {
+        opacity: 0;
+    }
+}

--- a/src/components/deck-status/deck-status.test.tsx
+++ b/src/components/deck-status/deck-status.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { DeckStatus } from './deck-status'
+import { resetShoe, drawCard } from '../../services/deck'
+
+describe('DeckStatus Component', () => {
+    beforeEach(() => {
+        resetShoe()
+    })
+
+    it('should display deck status information', () => {
+        render(<DeckStatus />)
+        expect(screen.getByText(/Decks:/)).toBeInTheDocument()
+        expect(screen.getByText(/Cards:/)).toBeInTheDocument()
+        expect(screen.getByText(/Penetration:/)).toBeInTheDocument()
+    })
+
+    it('should display initial deck values after reset', () => {
+        render(<DeckStatus />)
+        // After reset, we should have full shoe
+        expect(screen.getByText(/6\.0/)).toBeInTheDocument()
+        expect(screen.getByText(/312/)).toBeInTheDocument()
+        expect(screen.getByText(/0\.0%/)).toBeInTheDocument()
+    })
+
+    it('should display penetration level', () => {
+        render(<DeckStatus />)
+        expect(screen.getByText(/Low/)).toBeInTheDocument()
+    })
+
+    it('should have proper styling classes', () => {
+        render(<DeckStatus />)
+        const deckStatus = screen.getByText(/Decks:/)
+        // Just verify the element exists and has some class
+        expect(deckStatus).toBeInTheDocument()
+        expect(deckStatus.className).toBeTruthy()
+    })
+})

--- a/src/components/deck-status/deck-status.tsx
+++ b/src/components/deck-status/deck-status.tsx
@@ -1,0 +1,90 @@
+import { useState, useEffect } from 'react'
+import {
+    getShoeStatus,
+    getPenetrationLimit,
+    getNumberOfDecks,
+} from '../../services/deck'
+import * as styles from './deck-status.module.css'
+
+export const DeckStatus = () => {
+    const [shoeStatus, setShoeStatus] = useState(getShoeStatus())
+    const [showNotification, setShowNotification] = useState(false)
+    const penetrationLimit = getPenetrationLimit()
+    const numberOfDecks = getNumberOfDecks()
+
+    useEffect(() => {
+        const checkStatus = () => {
+            const status = getShoeStatus()
+            setShoeStatus(status)
+
+            // Show notification if deck was just reshuffled
+            if (status.wasJustReshuffled) {
+                setShowNotification(true)
+                const timer = setTimeout(() => {
+                    setShowNotification(false)
+                }, 3000)
+                return () => clearTimeout(timer)
+            }
+        }
+
+        checkStatus()
+        const interval = setInterval(checkStatus, 1000)
+
+        return () => clearInterval(interval)
+    }, [])
+
+    const penetrationPercentage = shoeStatus.penetrationPercentage
+    const decksRemaining = shoeStatus.decksRemaining
+    const remainingCards = shoeStatus.remainingCards
+    const totalCards = shoeStatus.totalCards
+
+    // Calculate penetration level
+    const getPenetrationLevel = (): string => {
+        if (penetrationPercentage < 25) return 'Low'
+        if (penetrationPercentage < 50) return 'Medium'
+        if (penetrationPercentage < 75) return 'High'
+        return 'Reshuffle Soon'
+    }
+
+    const penetrationLevel = getPenetrationLevel()
+
+    return (
+        <div className={styles.deckStatusContainer}>
+            <div className={styles.deckStatusContent}>
+                <div className={styles.statusItem}>
+                    <span className={styles.statusLabel}>Decks:</span>
+                    <span className={styles.statusValue}>
+                        {decksRemaining.toFixed(1)} / {numberOfDecks}
+                    </span>
+                </div>
+                <div className={styles.statusItem}>
+                    <span className={styles.statusLabel}>Cards:</span>
+                    <span className={styles.statusValue}>
+                        {remainingCards} / {totalCards}
+                    </span>
+                </div>
+                <div className={styles.statusItem}>
+                    <span className={styles.statusLabel}>Penetration:</span>
+                    <span
+                        className={`${styles.statusValue} ${
+                            styles[
+                                `penetration${penetrationLevel.replace(
+                                    /\s+/g,
+                                    ''
+                                )}`
+                            ]
+                        }`}
+                    >
+                        {penetrationPercentage.toFixed(1)}% ({penetrationLevel})
+                    </span>
+                </div>
+            </div>
+
+            {showNotification && (
+                <div className={styles.reshuffleNotification}>
+                    🔄 Deck Reshuffled!
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/services/deck.test.ts
+++ b/src/services/deck.test.ts
@@ -1,48 +1,159 @@
-import { dealHand, drawCard } from './deck';
-import { CardValue, CardSuit } from '../interfaces/card.interface';
+import {
+    dealHand,
+    drawCard,
+    getShoeStatus,
+    resetShoe,
+    getPenetrationLimit,
+    getNumberOfDecks,
+    ShoeStatus,
+} from './deck'
+import { CardValue, CardSuit } from '../interfaces/card.interface'
 
-describe('deck service', () => {
-    it('should draw a card and reduce shoe size', () => {
-        const card = drawCard();
-        expect(card).toBeDefined();
-        expect(Object.values(CardValue)).toContain(card.value);
-        expect(Object.values(CardSuit)).toContain(card.suit);
-    });
+describe('Deck Service', () => {
+    beforeEach(() => {
+        resetShoe()
+    })
 
-    it('should deal a hand with two cards', () => {
-        const hand = dealHand();
-        expect(hand.cards.length).toBe(2);
-        expect(hand.finished).toBe(false);
-    });
+    describe('getNumberOfDecks', () => {
+        it('should return the number of decks in the shoe', () => {
+            expect(getNumberOfDecks()).toBe(6)
+        })
+    })
 
-    it('should maintain a shoe across multiple draws', () => {
-        // Drawing many cards should not crash and should return valid cards
-        for (let i = 0; i < 100; i++) {
-            const card = drawCard();
-            expect(card).toBeDefined();
-        }
-    });
+    describe('getPenetrationLimit', () => {
+        it('should return the penetration limit', () => {
+            expect(getPenetrationLimit()).toBe(0.75)
+        })
+    })
 
-    it('should reshuffle when penetration limit is reached', () => {
-        // The shoe has 6 decks = 312 cards. 
-        // Penetration limit is 75% = 234 cards.
-        // At 234 cards used (78 cards left), dealHand should trigger reshuffle.
-        
-        // This is a bit tricky to test without exposing 'shoe' or 'buildNewShoe',
-        // but we can observe behavior by drawing almost the whole shoe.
-        
-        // Clear/reset shoe by drawing until empty if needed (state persists in module)
-        // Since we can't reset, we just draw enough to hit the limit.
-        const totalCards = 6 * 52;
-        const limit = totalCards * 0.75;
-        
-        // Draw enough to be near the limit
-        for (let i = 0; i < limit + 10; i++) {
-            drawCard();
-        }
-        
-        // This dealHand should have triggered a reshuffle if we were past limit
-        const hand = dealHand();
-        expect(hand.cards.length).toBe(2);
-    });
-});
+    describe('getShoeStatus', () => {
+        it('should return initial shoe status', () => {
+            const status = getShoeStatus()
+            expect(status.totalCards).toBe(6 * 52) // 6 decks
+            expect(status.remainingCards).toBe(6 * 52)
+            expect(status.penetrationPercentage).toBe(0)
+            expect(status.decksRemaining).toBe(6)
+            expect(status.reshuffleCount).toBe(0)
+            expect(status.wasJustReshuffled).toBe(false)
+        })
+
+        it('should update remaining cards after drawing', () => {
+            drawCard()
+            const status = getShoeStatus()
+            expect(status.remainingCards).toBe(6 * 52 - 1)
+            expect(status.penetrationPercentage).toBeCloseTo(
+                (1 / (6 * 52)) * 100,
+                2
+            )
+        })
+
+        it('should update decks remaining after drawing', () => {
+            // Draw 52 cards (1 deck)
+            for (let i = 0; i < 52; i++) {
+                drawCard()
+            }
+            const status = getShoeStatus()
+            expect(status.decksRemaining).toBeCloseTo(5, 1)
+        })
+    })
+
+    describe('dealHand', () => {
+        it('should return a hand with 2 cards', () => {
+            const hand = dealHand()
+            expect(hand.cards.length).toBe(2)
+            expect(hand.finished).toBe(false)
+        })
+
+        it('should reduce remaining cards by 2', () => {
+            const initialStatus = getShoeStatus()
+            dealHand()
+            const newStatus = getShoeStatus()
+            expect(newStatus.remainingCards).toBe(
+                initialStatus.remainingCards - 2
+            )
+        })
+
+        it('should not be finished', () => {
+            const hand = dealHand()
+            expect(hand.finished).toBe(false)
+        })
+    })
+
+    describe('drawCard', () => {
+        it('should return a card', () => {
+            const card = drawCard()
+            expect(card).toHaveProperty('value')
+            expect(card).toHaveProperty('suit')
+        })
+
+        it('should reduce remaining cards by 1', () => {
+            const initialStatus = getShoeStatus()
+            drawCard()
+            const newStatus = getShoeStatus()
+            expect(newStatus.remainingCards).toBe(
+                initialStatus.remainingCards - 1
+            )
+        })
+
+        it('should reshuffle when penetration limit is reached', () => {
+            const initialStatus = getShoeStatus()
+
+            // Draw enough cards to reach penetration limit (75%)
+            const cardsToDraw = Math.floor(6 * 52 * 0.75) + 1
+            for (let i = 0; i < cardsToDraw; i++) {
+                drawCard()
+            }
+
+            const statusAfterDrawing = getShoeStatus()
+            expect(statusAfterDrawing.reshuffleCount).toBeGreaterThan(
+                initialStatus.reshuffleCount
+            )
+        })
+
+        it('should increment reshuffle count when shoe is rebuilt', () => {
+            const initialStatus = getShoeStatus()
+
+            // Draw all cards to force reshuffle
+            for (let i = 0; i < 6 * 52; i++) {
+                drawCard()
+            }
+
+            // Draw one more to trigger reshuffle
+            drawCard()
+
+            const finalStatus = getShoeStatus()
+            expect(finalStatus.reshuffleCount).toBeGreaterThan(
+                initialStatus.reshuffleCount
+            )
+        })
+    })
+
+    describe('resetShoe', () => {
+        it('should reset the shoe', () => {
+            drawCard()
+            resetShoe()
+            const status = getShoeStatus()
+            expect(status.remainingCards).toBe(6 * 52)
+            expect(status.reshuffleCount).toBe(0)
+        })
+    })
+
+    describe('Card Distribution', () => {
+        it('should return valid cards', () => {
+            resetShoe()
+            const card = drawCard()
+            expect(card).toHaveProperty('value')
+            expect(card).toHaveProperty('suit')
+            expect(Object.values(CardValue)).toContain(card.value)
+            expect(Object.values(CardSuit)).toContain(card.suit)
+        })
+
+        it('should return different cards on subsequent draws', () => {
+            resetShoe()
+            const card1 = drawCard()
+            const card2 = drawCard()
+            // Cards should be different objects (though they might have same value/suit)
+            expect(card1).not.toBe(card2)
+        })
+    })
+})

--- a/src/services/deck.ts
+++ b/src/services/deck.ts
@@ -10,9 +10,34 @@ const NUMBER_OF_DECKS = 6
 const PENETRATION_LIMIT = 0.75
 
 let shoe: Card[] = []
+let lastShoeLength = 0
+let reshuffleCount = 0
+
+// Track if we just reshuffled
+let justReshuffled = false
+
+// Initialize shoe on first use
+function initializeShoe(): void {
+    if (shoe.length === 0) {
+        buildNewShoe()
+    }
+}
+
+export interface ShoeStatus {
+    totalCards: number
+    remainingCards: number
+    penetrationPercentage: number
+    decksRemaining: number
+    reshuffleCount: number
+    wasJustReshuffled: boolean
+}
 
 export function dealHand(): BlackjackHand {
-    checkShoePenetration()
+    initializeShoe()
+    const wasReshuffled = checkShoePenetration()
+    if (wasReshuffled) {
+        justReshuffled = true
+    }
     return {
         cards: [drawCard(), drawCard()],
         finished: false,
@@ -20,9 +45,19 @@ export function dealHand(): BlackjackHand {
 }
 
 export function drawCard(): Card {
+    initializeShoe()
+    checkShoePenetration()
     if (shoe.length === 0) {
         buildNewShoe()
+        justReshuffled = true
     }
+
+    // Reset justReshuffled flag after a card is drawn
+    if (justReshuffled && shoe.length < lastShoeLength) {
+        justReshuffled = false
+    }
+
+    lastShoeLength = shoe.length
     return shoe.pop()!
 }
 
@@ -52,12 +87,51 @@ function buildNewShoe(): void {
         })
     }
     shoe = shuffle(newShoe)
+    reshuffleCount++
 }
 
-function checkShoePenetration(): void {
+function checkShoePenetration(): boolean {
     const totalCards = NUMBER_OF_DECKS * 52
     const usedCards = totalCards - shoe.length
     if (shoe.length === 0 || usedCards / totalCards >= PENETRATION_LIMIT) {
         buildNewShoe()
+        return true
     }
+    return false
+}
+
+export function getShoeStatus(): ShoeStatus {
+    const totalCards = NUMBER_OF_DECKS * 52
+    const remainingCards = shoe.length
+    const usedCards = totalCards - remainingCards
+    const penetrationPercentage = (usedCards / totalCards) * 100
+    const decksRemaining = remainingCards / 52
+
+    return {
+        totalCards,
+        remainingCards,
+        penetrationPercentage,
+        decksRemaining,
+        reshuffleCount,
+        wasJustReshuffled: justReshuffled,
+    }
+}
+
+export function resetShoe(): void {
+    shoe = []
+    lastShoeLength = 0
+    reshuffleCount = 0
+    justReshuffled = false
+    // Rebuild the shoe immediately
+    buildNewShoe()
+    // Reset reshuffle count back to 0 since this is the initial build
+    reshuffleCount = 0
+}
+
+export function getPenetrationLimit(): number {
+    return PENETRATION_LIMIT
+}
+
+export function getNumberOfDecks(): number {
+    return NUMBER_OF_DECKS
 }


### PR DESCRIPTION
# Add Deck Penetration and Reshuffling Logic

Closes #36

## Summary of Changes

This PR implements comprehensive deck penetration and reshuffling logic as specified in issue #36.

### New Features
- **Enhanced Deck Service** (`src/services/deck.ts`):
  - Added `getShoeStatus()` function to expose real-time shoe information
  - Enhanced `checkShoePenetration()` to trigger reshuffles at 75% penetration
  - Added tracking for remaining cards, penetration percentage, decks remaining, and reshuffle count
  - Added `resetShoe()` function for testing and fresh starts
- **DeckStatus Component** (`src/components/deck-status/deck-status.tsx`):
  - Displays real-time shoe information in a fixed panel
  - Shows decks remaining, cards remaining, and penetration percentage
  - Color-coded penetration levels (Low, Medium, High, Reshuffle Soon)
  - Animated notification when deck is reshuffled

### Files Changed
- `src/services/deck.ts` - Enhanced with shoe status tracking and penetration logic
- `src/services/deck.test.ts` - Comprehensive unit tests for deck service
- `src/components/deck-status/deck-status.tsx` - New DeckStatus component
- `src/components/deck-status/deck-status.module.css` - Styling for component
- `src/components/deck-status/deck-status.test.tsx` - Unit tests for component
- `src/components/app/app.tsx` - Integrated DeckStatus component into App

### Testing
All new code includes comprehensive unit tests:
- Service tests verify shoe status calculations and reshuffling logic
- Component tests verify rendering and display of deck information
- All 19 tests pass successfully

### Acceptance Criteria Met
✅ Support multi-deck play (6-deck shoe)
✅ Implement a 'cut card' or penetration threshold (75%)
✅ Display a UI notification or animation when the deck is reshuffled
✅ Ensure the 'draw' service correctly tracks the remaining cards in the shoe across hands
✅ Add a visual indicator of the remaining deck size/penetration

### Notes
- The existing deck service already had basic penetration logic, which has been enhanced
- The DeckStatus component provides real-time visibility into shoe state
- Reshuffle notifications appear briefly when the deck is reshuffled
- Penetration levels are color-coded for easy visual reference
