### PR TITLE
66: Fix doubleDown bug - Dealer does not play if game is over

### DIFF
--- a/src/js/game.js
+++ b/src/js/game.js
@@ -217,7 +217,29 @@ function doubleDown() {
 }
 
 function isGameOver() {
-    return !!document.getElementById('result').textContent;
+    const resultElement = document.getElementById('result');
+    if (resultElement && resultElement.textContent) {
+        return true;
+    }
+    
+    // Check for player bust
+    let playerTotal = calculateTotal(getCardValuesFromPlayerHand());
+    if (playerTotal.hardValue > 21 && (playerTotal.softValue > 21 || playerTotal.softValue == null)) {
+        return true;
+    }
+    
+    // Check for blackjack
+    if (playerTotal.hardValue === 21 && getCardValuesFromPlayerHand().length === 2) {
+        return true;
+    }
+    
+    // Check for dealer blackjack
+    let dealerTotal = calculateTotal(getCardValuesFromDealerHand());
+    if (dealerTotal.hardValue === 21 && getCardValuesFromDealerHand().length === 2) {
+        return true;
+    }
+    
+    return false;
 }
 
 function restartGame() {

--- a/src/js/game.test.js
+++ b/src/js/game.test.js
@@ -1,0 +1,115 @@
+// game.test.js
+// Unit tests for game.js logic
+
+const {
+    isGameOver,
+    doubleDown,
+    hit,
+    playForDealer,
+    startGame,
+    dealerHand,
+    playerHand,
+    calculateTotal,
+    getCardValuesFromPlayerHand,
+    getCardValuesFromDealerHand,
+    setEndCondition,
+    clearEndCondition
+} = require('./game');
+
+// Mock DOM elements
+beforeEach(() => {
+    document.body.innerHTML = `
+        <div id="result"></div>
+        <div id="visualDealerHand"></div>
+        <div id="dealerTotal"></div>
+        <div id="visualPlayerHand"></div>
+        <div id="playerTotal"></div>
+        <div id="action-buttons">
+            <button id="double-down" disabled></button>
+            <button id="hit"></button>
+            <button id="stand"></button>
+        </div>
+        <button id="restart-game" class="hidden"></button>
+    `;
+    
+    // Reset hands
+    dealerHand = [];
+    playerHand = [];
+    clearEndCondition();
+});
+
+// Test isGameOver function
+describe('isGameOver', () => {
+    test('returns true if result element has text', () => {
+        setEndCondition('YOU LOSE');
+        expect(isGameOver()).toBe(true);
+    });
+    
+    test('returns true if player busts', () => {
+        playerHand = [['K', 'hearts'], ['Q', 'diamonds'], ['J', 'spades']]; // Hard total = 30
+        expect(isGameOver()).toBe(true);
+    });
+    
+    test('returns true if player has blackjack', () => {
+        playerHand = [['A', 'hearts'], ['K', 'diamonds']]; // Blackjack
+        expect(isGameOver()).toBe(true);
+    });
+    
+    test('returns true if dealer has blackjack', () => {
+        dealerHand = [['A', 'hearts'], ['K', 'diamonds']]; // Blackjack
+        expect(isGameOver()).toBe(true);
+    });
+    
+    test('returns false if game is not over', () => {
+        playerHand = [['K', 'hearts'], ['5', 'diamonds']]; // Hard total = 15
+        dealerHand = [['7', 'hearts'], ['10', 'diamonds']]; // Hard total = 17
+        expect(isGameOver()).toBe(false);
+    });
+});
+
+// Test doubleDown function
+describe('doubleDown', () => {
+    test('does not call playForDealer if game is over after hit', () => {
+        // Mock hit to force a bust
+        const originalHit = hit;
+        hit = jest.fn(() => {
+            playerHand.push(['K', 'hearts']); // Force bust
+        });
+        
+        // Mock playForDealer to track calls
+        const originalPlayForDealer = playForDealer;
+        playForDealer = jest.fn();
+        
+        playerHand = [['K', 'hearts'], ['5', 'diamonds']]; // Hard total = 15
+        doubleDown();
+        
+        expect(hit).toHaveBeenCalled();
+        expect(playForDealer).not.toHaveBeenCalled();
+        
+        // Restore original functions
+        hit = originalHit;
+        playForDealer = originalPlayForDealer;
+    });
+    
+    test('calls playForDealer if game is not over after hit', () => {
+        // Mock hit to add a card without busting
+        const originalHit = hit;
+        hit = jest.fn(() => {
+            playerHand.push(['2', 'hearts']); // Hard total = 17
+        });
+        
+        // Mock playForDealer to track calls
+        const originalPlayForDealer = playForDealer;
+        playForDealer = jest.fn();
+        
+        playerHand = [['K', 'hearts'], ['5', 'diamonds']]; // Hard total = 15
+        doubleDown();
+        
+        expect(hit).toHaveBeenCalled();
+        expect(playForDealer).toHaveBeenCalled();
+        
+        // Restore original functions
+        hit = originalHit;
+        playForDealer = originalPlayForDealer;
+    });
+});


### PR DESCRIPTION
This PR fixes the doubleDown bug where the dealer continues to play even if the game is already over (e.g., the player busts or wins).

### Changes:
- Updated the  function to check the game state directly (player bust, blackjack, or dealer blackjack).
- Ensured  does not call  if the game is over after the .
- Added unit tests for  and .

### Issue Link:
https://github.com/jacketattack/blackjack-is-fun/issues/66