### PR TITLE
65: Implement split functionality for pairs

### DIFF
--- a/src/js/game.js
+++ b/src/js/game.js
@@ -1,5 +1,7 @@
 var dealerHand;
 var playerHand;
+var splitHands = [];
+var activeHandIndex = 0;
 
 function startGame() {
     // assume one player for now
@@ -41,12 +43,40 @@ function enableSplitAction() {
 }
 
 function split() {
-    console.log('IMPLEMENT ME');
-    // TODO: tooltip
-    // make two hands
-    // make them separate sections but add class to denote one as active
-    // allow for resplit..
-    // i guess it's just hte same .. kind of recursive operation
+    // Check if player has exactly 2 cards and they are a pair
+    if (playerHand.length !== 2) {
+        console.log('Cannot split: Player does not have exactly 2 cards.');
+        return;
+    }
+    
+    const firstCardValue = convertCardValueToBlackjackValue(playerHand[0][0]);
+    const secondCardValue = convertCardValueToBlackjackValue(playerHand[1][0]);
+    
+    if (firstCardValue !== secondCardValue) {
+        console.log('Cannot split: Cards are not a pair.');
+        return;
+    }
+    
+    // Create two split hands
+    const hand1 = [playerHand[0]];
+    const hand2 = [playerHand[1]];
+    
+    // Deal an additional card to each hand
+    hand1.push(dealOneCard());
+    hand2.push(dealOneCard());
+    
+    // Store split hands
+    splitHands = [hand1, hand2];
+    activeHandIndex = 0;
+    
+    // Update UI to show split hands
+    visualizeSplitHands();
+    
+    // Disable split button for now (can be re-enabled if active hand is a pair)
+    document.getElementById('split').setAttribute('disabled', true);
+    
+    // Check if active hand can be split again
+    checkForResplit();
 }
 
 function dealOneCard() {
@@ -82,9 +112,41 @@ function getCardValuesFromPlayerHand() {
 }
 
 function visualizePlayerHandAndTotal() {
-    document.getElementById('visualPlayerHand').textContent = stringifyHand(playerHand);
+    if (splitHands.length > 0) {
+        visualizeSplitHands();
+    } else {
+        document.getElementById('visualPlayerHand').textContent = stringifyHand(playerHand);
+        document.getElementById('playerTotal').textContent = getVisualTotal(getCardValuesFromPlayerHand());
+    }
+}
 
-    document.getElementById('playerTotal').textContent = getVisualTotal(getCardValuesFromPlayerHand());
+function visualizeSplitHands() {
+    const activeHand = splitHands[activeHandIndex];
+    const otherHand = splitHands[1 - activeHandIndex];
+    
+    // Display active hand with indicator
+    const activeHandStr = stringifyHand(activeHand);
+    const activeTotal = getVisualTotal(activeHand.map(card => card[0]));
+    
+    // Display other hand
+    const otherHandStr = stringifyHand(otherHand);
+    const otherTotal = getVisualTotal(otherHand.map(card => card[0]));
+    
+    // Update UI to show both hands
+    document.getElementById('visualPlayerHand').textContent = 
+        `Active: ${activeHandStr} (${activeTotal}) | Other: ${otherHandStr} (${otherTotal})`;
+    document.getElementById('playerTotal').textContent = `Active Total: ${activeTotal}`;
+}
+
+function checkForResplit() {
+    const activeHand = splitHands[activeHandIndex];
+    if (activeHand.length === 2) {
+        const firstCardValue = convertCardValueToBlackjackValue(activeHand[0][0]);
+        const secondCardValue = convertCardValueToBlackjackValue(activeHand[1][0]);
+        if (firstCardValue === secondCardValue) {
+            document.getElementById('split').removeAttribute('disabled');
+        }
+    }
 }
 
 function getVisualTotal(cardValues) {
@@ -185,11 +247,27 @@ function convertCardValueToBlackjackValue(cardValue) {
 }
 
 function hit(){
-    playerHand.push(dealOneCard());
-    visualizePlayerHandAndTotal();
-    disableDoubleDown();
+    if (splitHands.length > 0) {
+        // Add card to active split hand
+        splitHands[activeHandIndex].push(dealOneCard());
+        visualizeSplitHands();
+        disableDoubleDown();
+        checkForPlayerBustInActiveHand();
+    } else {
+        playerHand.push(dealOneCard());
+        visualizePlayerHandAndTotal();
+        disableDoubleDown();
+        checkForPlayerBust();
+    }
+}
 
-    checkForPlayerBust();
+function checkForPlayerBustInActiveHand() {
+    const activeHand = splitHands[activeHandIndex];
+    let activeHandTotal = calculateTotal(activeHand.map(card => card[0]));
+    if (activeHandTotal.hardValue > 21 && (activeHandTotal.softValue > 21 || activeHandTotal.softValue == null)) {
+        visualizeDealerHandAndTotal();
+        playerLoses();
+    }
 }
 
 function checkForPlayerBust() {
@@ -209,15 +287,63 @@ function disableDoubleDown() {
 }
 
 function doubleDown() {
-    hit();
-    // TODO: bug is here.. do not play for dealer if game is over
-    if (!isGameOver()) {
-        playForDealer();
+    if (splitHands.length > 0) {
+        // Double down on active split hand
+        hit();
+        if (!isGameOver()) {
+            // Move to next hand or play for dealer
+            if (activeHandIndex === 0) {
+                activeHandIndex = 1;
+                visualizeSplitHands();
+            } else {
+                playForDealer();
+            }
+        }
+    } else {
+        hit();
+        if (!isGameOver()) {
+            playForDealer();
+        }
     }
 }
 
 function isGameOver() {
-    return !!document.getElementById('result').textContent;
+    const resultElement = document.getElementById('result');
+    if (resultElement && resultElement.textContent) {
+        return true;
+    }
+    
+    if (splitHands.length > 0) {
+        // Check all split hands for bust or blackjack
+        for (const hand of splitHands) {
+            const handTotal = calculateTotal(hand.map(card => card[0]));
+            if (handTotal.hardValue > 21 && (handTotal.softValue > 21 || handTotal.softValue == null)) {
+                return true;
+            }
+            if (handTotal.hardValue === 21 && hand.length === 2) {
+                return true;
+            }
+        }
+    } else {
+        // Check for player bust
+        let playerTotal = calculateTotal(getCardValuesFromPlayerHand());
+        if (playerTotal.hardValue > 21 && (playerTotal.softValue > 21 || playerTotal.softValue == null)) {
+            return true;
+        }
+        
+        // Check for blackjack
+        if (playerTotal.hardValue === 21 && getCardValuesFromPlayerHand().length === 2) {
+            return true;
+        }
+    }
+    
+    // Check for dealer blackjack
+    let dealerTotal = calculateTotal(getCardValuesFromDealerHand());
+    if (dealerTotal.hardValue === 21 && getCardValuesFromDealerHand().length === 2) {
+        return true;
+    }
+    
+    return false;
 }
 
 function restartGame() {
@@ -285,25 +411,42 @@ function playForDealer() {
 
     visualizeDealerHandAndTotal();
 
-    // check for result
-    finalDealerHard = calculateTotal(getCardValuesFromDealerHand()).hardValue;
-    finalDealerSoft = calculateTotal(getCardValuesFromDealerHand()).softValue; 
-    let finalDealerTotal = getTrueHandValue(finalDealerHard, finalDealerSoft);
-
-
-    finalPlayerHard = calculateTotal(getCardValuesFromPlayerHand()).hardValue;
-    finalPlayerSoft = calculateTotal(getCardValuesFromPlayerHand()).softValue; 
-    let finalPlayerTotal = getTrueHandValue(finalPlayerHard, finalPlayerSoft);
-
-
-    if (finalDealerTotal > 21) {
-        playerWins();
-    } else if (finalDealerTotal > finalPlayerTotal) {
-        playerLoses();
-    } else if (finalPlayerTotal > finalDealerTotal) {
-        playerWins();
+    if (splitHands.length > 0) {
+        // Evaluate all split hands against dealer
+        for (const hand of splitHands) {
+            const handTotal = calculateTotal(hand.map(card => card[0]));
+            const finalHandTotal = getTrueHandValue(handTotal.hardValue, handTotal.softValue);
+            
+            const dealerTotal = calculateTotal(getCardValuesFromDealerHand());
+            const finalDealerTotal = getTrueHandValue(dealerTotal.hardValue, dealerTotal.softValue);
+            
+            if (finalDealerTotal > 21) {
+                playerWins();
+            } else if (finalDealerTotal > finalHandTotal) {
+                playerLoses();
+            } else if (finalHandTotal > finalDealerTotal) {
+                playerWins();
+            } else {
+                playerDraws();
+            }
+        }
     } else {
-        playerDraws();
+        // check for result
+        const dealerTotal = calculateTotal(getCardValuesFromDealerHand());
+        const finalDealerTotal = getTrueHandValue(dealerTotal.hardValue, dealerTotal.softValue);
+
+        const playerTotal = calculateTotal(getCardValuesFromPlayerHand());
+        const finalPlayerTotal = getTrueHandValue(playerTotal.hardValue, playerTotal.softValue);
+
+        if (finalDealerTotal > 21) {
+            playerWins();
+        } else if (finalDealerTotal > finalPlayerTotal) {
+            playerLoses();
+        } else if (finalPlayerTotal > finalDealerTotal) {
+            playerWins();
+        } else {
+            playerDraws();
+        }
     }
 
 }

--- a/src/js/game.test.js
+++ b/src/js/game.test.js
@@ -1,0 +1,144 @@
+// game.test.js
+// Unit tests for game.js logic
+
+const {
+    isGameOver,
+    doubleDown,
+    hit,
+    playForDealer,
+    startGame,
+    dealerHand,
+    playerHand,
+    splitHands,
+    activeHandIndex,
+    calculateTotal,
+    getCardValuesFromPlayerHand,
+    getCardValuesFromDealerHand,
+    setEndCondition,
+    clearEndCondition,
+    split
+} = require('./game');
+
+// Mock DOM elements
+beforeEach(() => {
+    document.body.innerHTML = `
+        <div id="result"></div>
+        <div id="visualDealerHand"></div>
+        <div id="dealerTotal"></div>
+        <div id="visualPlayerHand"></div>
+        <div id="playerTotal"></div>
+        <div id="action-buttons">
+            <button id="double-down" disabled></button>
+            <button id="hit"></button>
+            <button id="stand"></button>
+            <button id="split" disabled></button>
+        </div>
+        <button id="restart-game" class="hidden"></button>
+    `;
+    
+    // Reset hands
+    dealerHand = [];
+    playerHand = [];
+    splitHands = [];
+    activeHandIndex = 0;
+    clearEndCondition();
+});
+
+// Test isGameOver function
+describe('isGameOver', () => {
+    test('returns true if result element has text', () => {
+        setEndCondition('YOU LOSE');
+        expect(isGameOver()).toBe(true);
+    });
+    
+    test('returns true if player busts', () => {
+        playerHand = [['K', 'hearts'], ['Q', 'diamonds'], ['J', 'spades']]; // Hard total = 30
+        expect(isGameOver()).toBe(true);
+    });
+    
+    test('returns true if player has blackjack', () => {
+        playerHand = [['A', 'hearts'], ['K', 'diamonds']]; // Blackjack
+        expect(isGameOver()).toBe(true);
+    });
+    
+    test('returns true if dealer has blackjack', () => {
+        dealerHand = [['A', 'hearts'], ['K', 'diamonds']]; // Blackjack
+        expect(isGameOver()).toBe(true);
+    });
+    
+    test('returns false if game is not over', () => {
+        playerHand = [['K', 'hearts'], ['5', 'diamonds']]; // Hard total = 15
+        dealerHand = [['7', 'hearts'], ['10', 'diamonds']]; // Hard total = 17
+        expect(isGameOver()).toBe(false);
+    });
+});
+
+// Test split function
+describe('split', () => {
+    test('does not split if player does not have exactly 2 cards', () => {
+        playerHand = [['K', 'hearts'], ['5', 'diamonds'], ['2', 'spades']]; // 3 cards
+        split();
+        expect(splitHands.length).toBe(0);
+    });
+    
+    test('does not split if cards are not a pair', () => {
+        playerHand = [['K', 'hearts'], ['5', 'diamonds']]; // Not a pair
+        split();
+        expect(splitHands.length).toBe(0);
+    });
+    
+    test('splits player hand into two hands if they have a pair', () => {
+        playerHand = [['K', 'hearts'], ['K', 'diamonds']]; // Pair of Kings
+        split();
+        expect(splitHands.length).toBe(2);
+        expect(splitHands[0].length).toBe(2); // Each hand has 2 cards (original + new card)
+        expect(splitHands[1].length).toBe(2);
+    });
+});
+
+// Test doubleDown function
+describe('doubleDown', () => {
+    test('does not call playForDealer if game is over after hit', () => {
+        // Mock hit to force a bust
+        const originalHit = hit;
+        hit = jest.fn(() => {
+            playerHand.push(['K', 'hearts']); // Force bust
+        });
+        
+        // Mock playForDealer to track calls
+        const originalPlayForDealer = playForDealer;
+        playForDealer = jest.fn();
+        
+        playerHand = [['K', 'hearts'], ['5', 'diamonds']]; // Hard total = 15
+        doubleDown();
+        
+        expect(hit).toHaveBeenCalled();
+        expect(playForDealer).not.toHaveBeenCalled();
+        
+        // Restore original functions
+        hit = originalHit;
+        playForDealer = originalPlayForDealer;
+    });
+    
+    test('calls playForDealer if game is not over after hit', () => {
+        // Mock hit to add a card without busting
+        const originalHit = hit;
+        hit = jest.fn(() => {
+            playerHand.push(['2', 'hearts']); // Hard total = 17
+        });
+        
+        // Mock playForDealer to track calls
+        const originalPlayForDealer = playForDealer;
+        playForDealer = jest.fn();
+        
+        playerHand = [['K', 'hearts'], ['5', 'diamonds']]; // Hard total = 15
+        doubleDown();
+        
+        expect(hit).toHaveBeenCalled();
+        expect(playForDealer).toHaveBeenCalled();
+        
+        // Restore original functions
+        hit = originalHit;
+        playForDealer = originalPlayForDealer;
+    });
+});


### PR DESCRIPTION
This PR implements the split functionality for pairs, allowing players to split their hand into two separate hands if they are dealt a pair.

### Changes:
- Implemented the  function to split the player's hand into two separate hands.
- Added  and  to track split hands.
- Updated  to display split hands.
- Added  to show both hands with active/inactive indicators.
- Added  to re-enable the split button if the active hand is a pair.
- Updated  to add cards to the active split hand.
- Updated  to handle doubling down on split hands.
- Updated  to check all split hands for bust or blackjack.
- Updated  to evaluate all split hands against the dealer.
- Added unit tests for the split functionality.

### Issue Link:
https://github.com/jacketattack/blackjack-is-fun/issues/65