### PR TITLE
91: Fix doubleDown bug - Dealer plays even if game is over

### DIFF
--- a/src/js/game.test.js
+++ b/src/js/game.test.js
@@ -6,7 +6,7 @@
 // Mock DOM elements for testing
 const mockDOM = () => {
     const elements = {};
-    
+
     // Mock document.getElementById
     document.getElementById = jest.fn((id) => {
         if (!elements[id]) {
@@ -26,13 +26,13 @@ const mockDOM = () => {
         }
         return elements[id];
     });
-    
+
     // Mock document.querySelectorAll
     document.querySelectorAll = jest.fn(() => []);
-    
+
     // Mock console.log
     console.log = jest.fn();
-    
+
     return elements;
 };
 
@@ -50,21 +50,21 @@ const mockDealOneCard = (cards) => {
 describe('Split Functionality', () => {
     let game;
     let mockElements;
-    
+
     beforeEach(() => {
         // Reset the game module by clearing the cache
         jest.resetModules();
         mockElements = mockDOM();
-        
+
         // Import the game module fresh
         game = require('./game');
-        
+
         // Reset game state
         game.playerHands = [];
         game.activeHandIndex = 0;
         game.isSplitMode = false;
     });
-    
+
     afterEach(() => {
         jest.clearAllMocks();
     });
@@ -73,9 +73,9 @@ describe('Split Functionality', () => {
         it('should start with one player hand', () => {
             // Mock Math.random for consistent card dealing
             jest.spyOn(Math, 'random').mockReturnValue(0.5);
-            
+
             game.startGame();
-            
+
             expect(game.playerHands.length).toBe(1);
             expect(game.playerHands[0].cards.length).toBe(2);
             expect(game.activeHandIndex).toBe(0);
@@ -97,10 +97,10 @@ describe('Split Functionality', () => {
         it('should not split if hand does not have exactly 2 cards', () => {
             // Add a third card to the hand
             game.playerHands[0].cards.push(['5', 'spades']);
-            
+
             const initialHandCount = game.playerHands.length;
             game.split();
-            
+
             expect(game.playerHands.length).toBe(initialHandCount);
             expect(console.log).toHaveBeenCalledWith('Cannot split: Hand does not have exactly 2 cards');
         });
@@ -108,10 +108,10 @@ describe('Split Functionality', () => {
         it('should not split if cards are not a pair', () => {
             // Change to non-pair
             game.playerHands[0].cards = [['10', 'hearts'], ['5', 'diamonds']];
-            
+
             const initialHandCount = game.playerHands.length;
             game.split();
-            
+
             expect(game.playerHands.length).toBe(initialHandCount);
             expect(console.log).toHaveBeenCalledWith('Cannot split: Not a pair');
         });
@@ -121,7 +121,7 @@ describe('Split Functionality', () => {
             jest.spyOn(game, 'dealOneCard')
                 .mockReturnValueOnce(['7', 'spades'])
                 .mockReturnValueOnce(['7', 'clubs']);
-            
+
             mockElements['visualPlayerHand'] = {
                 innerHTML: '',
                 appendChild: jest.fn()
@@ -130,20 +130,20 @@ describe('Split Functionality', () => {
                 children: [],
                 appendChild: jest.fn()
             };
-            
+
             const initialHandCount = game.playerHands.length;
             game.split();
-            
+
             // Should now have 2 hands
             expect(game.playerHands.length).toBe(2);
             expect(game.isSplitMode).toBe(true);
             expect(game.activeHandIndex).toBe(0);
-            
+
             // First hand should have original first card + new card
             expect(game.playerHands[0].cards.length).toBe(2);
             expect(game.playerHands[0].cards[0]).toEqual(['10', 'hearts']);
             expect(game.playerHands[0].cards[1]).toEqual(['7', 'spades']);
-            
+
             // Second hand should have original second card + new card
             expect(game.playerHands[1].cards.length).toBe(2);
             expect(game.playerHands[1].cards[0]).toEqual(['10', 'diamonds']);
@@ -155,7 +155,7 @@ describe('Split Functionality', () => {
             jest.spyOn(game, 'dealOneCard')
                 .mockReturnValueOnce(['10', 'spades'])
                 .mockReturnValueOnce(['10', 'clubs']);
-            
+
             mockElements['visualPlayerHand'] = {
                 innerHTML: '',
                 appendChild: jest.fn()
@@ -168,14 +168,14 @@ describe('Split Functionality', () => {
                 setAttribute: jest.fn(),
                 removeAttribute: jest.fn()
             };
-            
+
             game.split();
-            
+
             // After split, the active hand should be the first hand with two 10s
             const activeHand = game.getActiveHand();
             expect(activeHand.cards[0][0]).toBe('10');
             expect(activeHand.cards[1][0]).toBe('10');
-            
+
             // enableSplitIfPlayerHasPair should have been called
             // and split button should be enabled for the new pair
             expect(mockElements['split'].removeAttribute).toHaveBeenCalledWith('disabled');
@@ -189,7 +189,7 @@ describe('Split Functionality', () => {
                 { cards: [['5', 'spades'], ['5', 'clubs']], finished: false }
             ];
             game.activeHandIndex = 1;
-            
+
             const activeHand = game.getActiveHand();
             expect(activeHand).toEqual(game.playerHands[1]);
         });
@@ -199,9 +199,9 @@ describe('Split Functionality', () => {
                 { cards: [['10', 'hearts'], ['10', 'diamonds']], finished: true },
                 { cards: [['5', 'spades'], ['5', 'clubs']], finished: true }
             ];
-            
+
             expect(game.areAllHandsFinished()).toBe(true);
-            
+
             game.playerHands[1].finished = false;
             expect(game.areAllHandsFinished()).toBe(false);
         });
@@ -213,10 +213,10 @@ describe('Split Functionality', () => {
                 { cards: [['8', 'spades'], ['8', 'clubs']], finished: false }
             ];
             game.activeHandIndex = 0;
-            
+
             game.switchToNextHand();
             expect(game.activeHandIndex).toBe(1);
-            
+
             // Switch again
             game.switchToNextHand();
             expect(game.activeHandIndex).toBe(2);
@@ -229,7 +229,7 @@ describe('Split Functionality', () => {
                 { cards: [['8', 'spades'], ['8', 'clubs']], finished: true }
             ];
             game.activeHandIndex = 0;
-            
+
             game.switchToNextHand();
             // Should skip finished hands and wrap around to index 0
             expect(game.activeHandIndex).toBe(0);
@@ -244,7 +244,7 @@ describe('Split Functionality', () => {
             ];
             game.activeHandIndex = 0;
             game.isSplitMode = true;
-            
+
             mockElements['visualPlayerHand'] = {
                 textContent: '',
                 innerHTML: ''
@@ -259,12 +259,12 @@ describe('Split Functionality', () => {
 
         it('should add card to active hand only', () => {
             jest.spyOn(game, 'dealOneCard').mockReturnValue(['7', 'spades']);
-            
+
             const initialFirstHandLength = game.playerHands[0].cards.length;
             const initialSecondHandLength = game.playerHands[1].cards.length;
-            
+
             game.hit();
-            
+
             // Only the active hand (first hand) should have a new card
             expect(game.playerHands[0].cards.length).toBe(initialFirstHandLength + 1);
             expect(game.playerHands[1].cards.length).toBe(initialSecondHandLength);
@@ -299,11 +299,21 @@ describe('Split Functionality', () => {
             jest.spyOn(game, 'dealOneCard').mockReturnValue(['7', 'spades']);
             jest.spyOn(game, 'isGameOver').mockReturnValue(false);
             jest.spyOn(game, 'areAllHandsFinished').mockReturnValue(false);
-            
+
             game.doubleDown();
             
             expect(game.playerHands[0].finished).toBe(true);
             expect(game.playerHands[1].finished).toBe(false);
+        });
+        
+        it('should not call playForDealer if game is over after hit', () => {
+            jest.spyOn(game, 'dealOneCard').mockReturnValue(['K', 'spades']); // Causes bust
+            jest.spyOn(game, 'isGameOver').mockReturnValue(true); // Game over after hit
+            jest.spyOn(game, 'playForDealer').mockImplementation();
+            
+            game.doubleDown();
+            
+            expect(game.playForDealer).not.toHaveBeenCalled();
         });
 
         it('should switch to next hand if not all hands are finished', () => {
@@ -311,9 +321,9 @@ describe('Split Functionality', () => {
             jest.spyOn(game, 'isGameOver').mockReturnValue(false);
             jest.spyOn(game, 'areAllHandsFinished').mockReturnValue(false);
             jest.spyOn(game, 'switchToNextHand').mockImplementation();
-            
+
             game.doubleDown();
-            
+
             expect(game.switchToNextHand).toHaveBeenCalled();
         });
 
@@ -322,9 +332,9 @@ describe('Split Functionality', () => {
             jest.spyOn(game, 'isGameOver').mockReturnValue(false);
             jest.spyOn(game, 'areAllHandsFinished').mockReturnValue(true);
             jest.spyOn(game, 'playForDealer').mockImplementation();
-            
+
             game.doubleDown();
-            
+
             expect(game.playForDealer).toHaveBeenCalled();
         });
     });
@@ -337,7 +347,7 @@ describe('Split Functionality', () => {
             ];
             game.activeHandIndex = 0;
             game.isSplitMode = true;
-            
+
             jest.spyOn(game, 'areAllHandsFinished').mockReturnValue(false);
             jest.spyOn(game, 'switchToNextHand').mockImplementation();
             jest.spyOn(game, 'playForDealer').mockImplementation();
@@ -345,22 +355,22 @@ describe('Split Functionality', () => {
 
         it('should mark active hand as finished', () => {
             game.stand();
-            
+
             expect(game.playerHands[0].finished).toBe(true);
             expect(game.playerHands[1].finished).toBe(false);
         });
 
         it('should switch to next hand if not all hands are finished', () => {
             game.stand();
-            
+
             expect(game.switchToNextHand).toHaveBeenCalled();
         });
 
         it('should call playForDealer if all hands are finished', () => {
             game.areAllHandsFinished = jest.fn().mockReturnValue(true);
-            
+
             game.stand();
-            
+
             expect(game.playForDealer).toHaveBeenCalled();
         });
     });
@@ -373,14 +383,14 @@ describe('Split Functionality', () => {
             ];
             game.activeHandIndex = 0;
             game.isSplitMode = true;
-            
+
             mockElements['visualDealerHand'] = {
                 textContent: ''
             };
             mockElements['result'] = {
                 textContent: ''
             };
-            
+
             jest.spyOn(game, 'switchToNextHand').mockImplementation();
             jest.spyOn(game, 'playerLoses').mockImplementation();
         });
@@ -393,9 +403,9 @@ describe('Split Functionality', () => {
             });
             jest.spyOn(game, 'getTrueHandValue').mockReturnValue(32);
             jest.spyOn(game, 'areAllHandsFinished').mockReturnValue(false);
-            
+
             game.checkForPlayerBust();
-            
+
             expect(game.playerHands[0].finished).toBe(true);
             expect(game.switchToNextHand).toHaveBeenCalled();
         });
@@ -408,9 +418,9 @@ describe('Split Functionality', () => {
             });
             jest.spyOn(game, 'getTrueHandValue').mockReturnValue(32);
             jest.spyOn(game, 'areAllHandsFinished').mockReturnValue(true);
-            
+
             game.checkForPlayerBust();
-            
+
             expect(game.playerLoses).toHaveBeenCalled();
         });
     });
@@ -423,7 +433,7 @@ describe('Split Functionality', () => {
             ];
             game.activeHandIndex = 0;
             game.isSplitMode = true;
-            
+
             mockElements['visualPlayerHand'] = {
                 innerHTML: '',
                 textContent: ''
@@ -435,7 +445,7 @@ describe('Split Functionality', () => {
 
         it('should visualize all hands with active/inactive indicators in split mode', () => {
             game.visualizePlayerHandsAndTotals();
-            
+
             const playerHandElement = mockElements['visualPlayerHand'];
             expect(playerHandElement.innerHTML).toContain('active-hand');
             expect(playerHandElement.innerHTML).toContain('inactive-hand');
@@ -443,9 +453,9 @@ describe('Split Functionality', () => {
 
         it('should show total for active hand only', () => {
             jest.spyOn(game, 'getVisualTotal').mockReturnValue('20');
-            
+
             game.visualizePlayerHandsAndTotals();
-            
+
             const playerTotalElement = mockElements['playerTotal'];
             expect(playerTotalElement.textContent).toBe('20');
         });
@@ -455,7 +465,7 @@ describe('Split Functionality', () => {
         it('should get card values from hand', () => {
             const hand = [['10', 'hearts'], ['5', 'diamonds']];
             const values = game.getCardValuesFromHand(hand);
-            
+
             expect(values).toEqual(['10', '5']);
         });
 
@@ -465,14 +475,14 @@ describe('Split Functionality', () => {
                 finished: false
             }];
             game.activeHandIndex = 0;
-            
+
             mockElements['split'] = {
                 setAttribute: jest.fn(),
                 removeAttribute: jest.fn()
             };
-            
+
             game.updateSplitButtonState();
-            
+
             // Should enable split button for pair
             expect(mockElements['split'].removeAttribute).toHaveBeenCalledWith('disabled');
         });
@@ -483,14 +493,14 @@ describe('Split Functionality', () => {
                 finished: false
             }];
             game.activeHandIndex = 0;
-            
+
             mockElements['split'] = {
                 setAttribute: jest.fn(),
                 removeAttribute: jest.fn()
             };
-            
+
             game.updateSplitButtonState();
-            
+
             // Should disable split button for non-pair
             expect(mockElements['split'].setAttribute).toHaveBeenCalledWith('disabled', true);
         });
@@ -500,11 +510,11 @@ describe('Split Functionality', () => {
         it('should maintain backward compatibility with playerHand getter/setter', () => {
             // Set using the old API
             game.playerHand = [['10', 'hearts'], ['5', 'diamonds']];
-            
+
             // Get using the old API
             const hand = game.playerHand;
             expect(hand).toEqual([['10', 'hearts'], ['5', 'diamonds']]);
-            
+
             // Should be stored in the new format internally
             expect(game.playerHands[0].cards).toEqual([['10', 'hearts'], ['5', 'diamonds']]);
         });
@@ -515,7 +525,7 @@ describe('Split Functionality', () => {
                 finished: false
             }];
             game.activeHandIndex = 0;
-            
+
             const values = game.getCardValuesFromPlayerHand();
             expect(values).toEqual(['10', '5']);
         });
@@ -526,12 +536,12 @@ describe('Split Functionality', () => {
 describe('Split Functionality Integration', () => {
     let game;
     let mockElements;
-    
+
     beforeEach(() => {
         jest.resetModules();
         mockElements = mockDOM();
         game = require('./game');
-        
+
         // Reset game state
         game.playerHands = [];
         game.activeHandIndex = 0;
@@ -545,12 +555,12 @@ describe('Split Functionality Integration', () => {
             finished: false
         }];
         game.activeHandIndex = 0;
-        
+
         // Mock functions
         jest.spyOn(game, 'dealOneCard')
             .mockReturnValueOnce(['7', 'spades'])
             .mockReturnValueOnce(['7', 'clubs']);
-        
+
         mockElements['visualPlayerHand'] = {
             innerHTML: '',
             appendChild: jest.fn()
@@ -563,42 +573,42 @@ describe('Split Functionality Integration', () => {
             setAttribute: jest.fn(),
             removeAttribute: jest.fn()
         };
-        
+
         // Perform split
         game.split();
-        
+
         // Verify split was successful
         expect(game.playerHands.length).toBe(2);
         expect(game.isSplitMode).toBe(true);
-        
+
         // Now hit on first hand
         jest.spyOn(game, 'dealOneCard').mockReturnValue(['8', 'hearts']);
         mockElements['double-down'] = { setAttribute: jest.fn() };
         mockElements['playerTotal'] = { textContent: '' };
-        
+
         game.hit();
-        
+
         // First hand should have 3 cards now
         expect(game.playerHands[0].cards.length).toBe(3);
-        
+
         // Stand on first hand
         jest.spyOn(game, 'areAllHandsFinished').mockReturnValue(false);
         jest.spyOn(game, 'switchToNextHand').mockImplementation();
-        
+
         game.stand();
-        
+
         // First hand should be marked as finished
         expect(game.playerHands[0].finished).toBe(true);
-        
+
         // Switch to second hand
         game.activeHandIndex = 1;
-        
+
         // Stand on second hand
         game.areAllHandsFinished = jest.fn().mockReturnValue(true);
         jest.spyOn(game, 'playForDealer').mockImplementation();
-        
+
         game.stand();
-        
+
         // Should trigger dealer play since all hands are finished
         expect(game.playForDealer).toHaveBeenCalled();
     });


### PR DESCRIPTION
This PR fixes Issue #91 by ensuring the dealer does not play if the game is already over after the player doubles down.

### Changes
- Added a unit test to cover the  bug fix.
- Verified that the  check in  prevents the dealer from playing if the game is over.

### Testing
- Manually tested the  function in a browser.
- Added a unit test to prevent regressions.

### Issue Link
https://github.com/jacketattack/blackjack-is-fun/issues/91